### PR TITLE
Fix imports in analyzers package

### DIFF
--- a/instagram_analyzer/analyzers/__init__.py
+++ b/instagram_analyzer/analyzers/__init__.py
@@ -2,12 +2,16 @@
 
 from .basic_stats import BasicStatsAnalyzer
 from .temporal_analysis import TemporalAnalyzer
-from .sentiment_analysis import SentimentAnalyzer
-from .network_analysis import NetworkAnalyzer
+# TODO: implement SentimentAnalyzer module
+# from .sentiment_analysis import SentimentAnalyzer
+# TODO: implement NetworkAnalyzer module
+# from .network_analysis import NetworkAnalyzer
 
 __all__ = [
     "BasicStatsAnalyzer",
-    "TemporalAnalyzer", 
-    "SentimentAnalyzer",
-    "NetworkAnalyzer",
+    "TemporalAnalyzer",
+    # TODO: export SentimentAnalyzer when available
+    # "SentimentAnalyzer",
+    # TODO: export NetworkAnalyzer when available
+    # "NetworkAnalyzer",
 ]

--- a/instagram_analyzer/analyzers/basic_stats.py
+++ b/instagram_analyzer/analyzers/basic_stats.py
@@ -152,7 +152,10 @@ class BasicStatsAnalyzer:
         # Calculate consistency score (lower variance = higher consistency)
         if len(gaps) > 1:
             variance = sum((gap - average_gap) ** 2 for gap in gaps) / len(gaps)
-            consistency_score = max(0, 100 - (variance / average_gap * 10))
+            if average_gap == 0:
+                consistency_score = 100
+            else:
+                consistency_score = max(0, 100 - (variance / average_gap * 10))
         else:
             consistency_score = 100
         

--- a/instagram_analyzer/models/__init__.py
+++ b/instagram_analyzer/models/__init__.py
@@ -1,6 +1,6 @@
 """Pydantic models for Instagram data structures."""
 
-from .post import Post, Story, Reel
+from .post import Post, Story, Reel, ContentType
 from .user import User, Profile
 from .interaction import Comment, Like, Follow
 from .media import Media, MediaType
@@ -16,4 +16,5 @@ __all__ = [
     "Follow",
     "Media",
     "MediaType",
+    "ContentType",
 ]

--- a/instagram_analyzer/models/media.py
+++ b/instagram_analyzer/models/media.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 from typing import Optional, List
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from pydantic import BaseModel, Field, validator
@@ -46,7 +46,7 @@ class Media(BaseModel):
     @validator('creation_timestamp', 'taken_at')
     def validate_timestamps(cls, v: Optional[datetime]) -> Optional[datetime]:
         """Validate timestamp is not in the future."""
-        if v and v > datetime.now():
+        if v and v > datetime.now(timezone.utc):
             raise ValueError("Timestamp cannot be in the future")
         return v
     

--- a/instagram_analyzer/utils/__init__.py
+++ b/instagram_analyzer/utils/__init__.py
@@ -1,7 +1,14 @@
 """Utility functions and helpers."""
 
 from .file_utils import validate_path, get_file_size, safe_json_load
-from .date_utils import parse_instagram_date, format_date_range
+from .date_utils import (
+    parse_instagram_date,
+    format_date_range,
+    get_time_period_stats,
+    group_dates_by_period,
+    get_activity_hours,
+    get_activity_days_of_week,
+)
 from .privacy_utils import anonymize_data, detect_sensitive_info
 
 __all__ = [
@@ -10,6 +17,10 @@ __all__ = [
     "safe_json_load",
     "parse_instagram_date",
     "format_date_range",
+    "get_time_period_stats",
+    "group_dates_by_period",
+    "get_activity_hours",
+    "get_activity_days_of_week",
     "anonymize_data",
     "detect_sensitive_info",
 ]

--- a/instagram_analyzer/utils/date_utils.py
+++ b/instagram_analyzer/utils/date_utils.py
@@ -1,6 +1,6 @@
 """Date and time utility functions."""
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from typing import Union, Optional, Tuple
 from dateutil import parser
 
@@ -126,7 +126,7 @@ def group_dates_by_period(dates: list, period: str = "month") -> dict:
             key = date.strftime("%Y-%m-%d")
         elif period == "week":
             # Get Monday of the week
-            monday = date - datetime.timedelta(days=date.weekday())
+            monday = date - timedelta(days=date.weekday())
             key = monday.strftime("%Y-%m-%d")
         elif period == "month":
             key = date.strftime("%Y-%m")


### PR DESCRIPTION
## Summary
- remove unused SentimentAnalyzer and NetworkAnalyzer imports
- export missing ContentType model and utility functions
- guard against division by zero in consistency score
- fix timezone-aware timestamp validation
- expose date utilities in utils package
- comment out imports for missing modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873de278790832f93b1b7af1b4057a7