### PR TITLE
Fix HTML overview stats with reels

### DIFF
--- a/instagram_analyzer/exporters/html_exporter.py
+++ b/instagram_analyzer/exporters/html_exporter.py
@@ -1,6 +1,5 @@
 """Advanced HTML exporter for Instagram analysis reports."""
 
-
 import json
 from datetime import datetime
 from pathlib import Path
@@ -129,9 +128,14 @@ class HTMLExporter:
             1 for p in posts if any(m.media_type.value == "video" for m in p.media)
         )
 
-        # Engagement totals
-        total_likes = sum(p.likes_count for p in posts)
-        total_comments = sum(p.comments_count for p in posts)
+        # Engagement totals (include reels)
+        total_likes = sum(p.likes_count for p in posts) + sum(
+            r.likes_count for r in reels
+        )
+        total_comments = sum(p.comments_count for p in posts) + sum(
+            r.comments_count for r in reels
+        )
+        total_items = len(posts) + len(reels)
 
         return {
             "has_data": True,
@@ -155,10 +159,10 @@ class HTMLExporter:
                 "likes": total_likes,
                 "comments": total_comments,
                 "avg_likes_per_post": (
-                    round(total_likes / len(posts), 1) if posts else 0
+                    round(total_likes / total_items, 1) if total_items else 0
                 ),
                 "avg_comments_per_post": (
-                    round(total_comments / len(posts), 1) if posts else 0
+                    round(total_comments / total_items, 1) if total_items else 0
                 ),
             },
         }
@@ -465,7 +469,7 @@ class HTMLExporter:
 
     def _get_template(self) -> str:
         """Return the HTML report template contents."""
-        template_path = (
-            resources.files("instagram_analyzer.templates").joinpath("report.html")
+        template_path = resources.files("instagram_analyzer.templates").joinpath(
+            "report.html"
         )
         return template_path.read_text(encoding="utf-8")

--- a/tests/integration/test_instagram_analyzer.py
+++ b/tests/integration/test_instagram_analyzer.py
@@ -29,10 +29,10 @@ def mock_instagram_data(temp_dir):
     # Create directory structure
     content_dir = temp_dir / "content"
     content_dir.mkdir()
-    
+
     messages_dir = temp_dir / "messages"
     messages_dir.mkdir()
-    
+
     # Create mock posts data
     posts_data = [
         {
@@ -66,7 +66,7 @@ def mock_instagram_data(temp_dir):
             "title": "Test video post #test #video",
         },
     ]
-    
+
     # Create mock stories data
     stories_data = [
         {
@@ -75,7 +75,7 @@ def mock_instagram_data(temp_dir):
             "media_metadata": {"photo_metadata": {}},
         }
     ]
-    
+
     # Create mock profile data
     profile_data = {
         "username": "testuser",
@@ -87,17 +87,17 @@ def mock_instagram_data(temp_dir):
         "is_private": False,
         "is_verified": False,
     }
-    
+
     # Write JSON files
     with open(content_dir / "posts_1.json", "w") as f:
         json.dump(posts_data, f)
-    
+
     with open(content_dir / "stories.json", "w") as f:
         json.dump(stories_data, f)
-    
+
     with open(temp_dir / "personal_information.json", "w") as f:
         json.dump(profile_data, f)
-    
+
     return temp_dir
 
 
@@ -107,7 +107,7 @@ class TestInstagramAnalyzerInitialization:
     def test_init_with_valid_path(self, mock_instagram_data):
         """Test initialization with valid data path."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
+
         assert analyzer.data_path == mock_instagram_data
         assert analyzer.profile is None
         assert len(analyzer.posts) == 0
@@ -117,17 +117,17 @@ class TestInstagramAnalyzerInitialization:
     def test_init_with_invalid_path(self):
         """Test initialization with invalid data path."""
         invalid_path = Path("/nonexistent/path")
-        
+
         with pytest.raises(DataNotFoundError) as exc_info:
             InstagramAnalyzer(invalid_path)
-        
+
         assert "Invalid data path" in str(exc_info.value)
         assert exc_info.value.context["path"] == str(invalid_path)
 
     def test_init_with_nonexistent_directory(self, temp_dir):
         """Test initialization with non-existent directory."""
         nonexistent = temp_dir / "does_not_exist"
-        
+
         with pytest.raises(DataNotFoundError):
             InstagramAnalyzer(nonexistent)
 
@@ -138,9 +138,9 @@ class TestInstagramAnalyzerDataLoading:
     def test_load_data_success(self, mock_instagram_data):
         """Test successful data loading."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
+
         # Mock the data detector to return valid structure
-        with patch.object(analyzer.detector, 'detect_structure') as mock_detect:
+        with patch.object(analyzer.detector, "detect_structure") as mock_detect:
             mock_detect.return_value = {
                 "is_valid": True,
                 "export_type": "full_export",
@@ -151,9 +151,9 @@ class TestInstagramAnalyzerDataLoading:
                 "profile_files": [mock_instagram_data / "personal_information.json"],
                 "message_files": [],
             }
-            
+
             analyzer.load_data()
-            
+
             # Verify data was loaded
             assert len(analyzer.posts) >= 1
             assert len(analyzer.stories) >= 1
@@ -162,17 +162,17 @@ class TestInstagramAnalyzerDataLoading:
     def test_load_data_invalid_structure(self, mock_instagram_data):
         """Test loading data with invalid structure."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
-        with patch.object(analyzer.detector, 'detect_structure') as mock_detect:
+
+        with patch.object(analyzer.detector, "detect_structure") as mock_detect:
             mock_detect.return_value = {
                 "is_valid": False,
                 "export_type": "invalid",
                 "total_files": 0,
             }
-            
+
             with pytest.raises(InvalidDataFormatError) as exc_info:
                 analyzer.load_data()
-            
+
             assert "Invalid Instagram data export structure" in str(exc_info.value)
 
     def test_load_data_with_corrupted_json(self, temp_dir):
@@ -180,13 +180,13 @@ class TestInstagramAnalyzerDataLoading:
         # Create corrupted JSON file
         content_dir = temp_dir / "content"
         content_dir.mkdir()
-        
+
         with open(content_dir / "posts_1.json", "w") as f:
             f.write("{ invalid json")
-        
+
         analyzer = InstagramAnalyzer(temp_dir)
-        
-        with patch.object(analyzer.detector, 'detect_structure') as mock_detect:
+
+        with patch.object(analyzer.detector, "detect_structure") as mock_detect:
             mock_detect.return_value = {
                 "is_valid": True,
                 "export_type": "content_export",
@@ -197,7 +197,7 @@ class TestInstagramAnalyzerDataLoading:
                 "profile_files": [],
                 "message_files": [],
             }
-            
+
             # Should not raise exception, just skip corrupted files
             analyzer.load_data()
             assert len(analyzer.posts) == 0
@@ -209,35 +209,52 @@ class TestInstagramAnalyzerAnalysis:
     def test_analyze_with_data(self, mock_instagram_data):
         """Test analysis with loaded data."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
+
         # Mock loaded data
         analyzer.posts = [
             Post(
-                media=[Media(
-                    uri="test.jpg",
-                    media_type=MediaType.IMAGE,
-                    creation_timestamp=datetime.now(timezone.utc)
-                )],
+                media=[
+                    Media(
+                        uri="test.jpg",
+                        media_type=MediaType.IMAGE,
+                        creation_timestamp=datetime.now(timezone.utc),
+                    )
+                ],
                 timestamp=datetime.now(timezone.utc),
                 caption="Test post",
                 likes_count=10,
                 comments_count=5,
             )
         ]
-        
+        analyzer.reels = [
+            Reel(
+                video=Media(
+                    uri="reel.mp4",
+                    media_type=MediaType.VIDEO,
+                    creation_timestamp=datetime.now(timezone.utc),
+                ),
+                timestamp=datetime.now(timezone.utc),
+                caption="Test reel",
+                likes_count=7,
+                comments_count=2,
+            )
+        ]
+
         results = analyzer.analyze()
-        
+
         assert "total_posts" in results
         assert "total_likes" in results
         assert results["total_posts"] == 1
-        assert results["total_likes"] == 10
+        assert results["total_reels"] == 1
+        assert results["total_likes"] == 17
+        assert results["total_comments"] == 7
 
     def test_analyze_with_no_data(self, mock_instagram_data):
         """Test analysis with no data loaded."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
+
         results = analyzer.analyze()
-        
+
         assert results["total_posts"] == 0
         assert results["total_stories"] == 0
         assert results["total_reels"] == 0
@@ -245,22 +262,24 @@ class TestInstagramAnalyzerAnalysis:
     def test_analyze_with_include_media(self, mock_instagram_data):
         """Test analysis with media inclusion."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
+
         # Mock some data
         analyzer.posts = [
             Post(
-                media=[Media(
-                    uri="test.jpg",
-                    media_type=MediaType.IMAGE,
-                    creation_timestamp=datetime.now(timezone.utc)
-                )],
+                media=[
+                    Media(
+                        uri="test.jpg",
+                        media_type=MediaType.IMAGE,
+                        creation_timestamp=datetime.now(timezone.utc),
+                    )
+                ],
                 timestamp=datetime.now(timezone.utc),
                 caption="Test post",
             )
         ]
-        
+
         results = analyzer.analyze(include_media=True)
-        
+
         # Should still work even with media analysis enabled
         assert "total_posts" in results
 
@@ -271,13 +290,13 @@ class TestInstagramAnalyzerValidation:
     def test_validate_data_with_content(self, mock_instagram_data):
         """Test validation with loaded content."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
+
         # Mock some data
         analyzer.posts = [MagicMock()]
         analyzer.profile = MagicMock()
-        
+
         validation_results = analyzer.validate_data()
-        
+
         assert validation_results["data_loaded"]["valid"] is True
         assert validation_results["profile_data"]["valid"] is True
         assert validation_results["content_found"]["valid"] is True
@@ -285,9 +304,9 @@ class TestInstagramAnalyzerValidation:
     def test_validate_data_empty(self, mock_instagram_data):
         """Test validation with no data."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
+
         validation_results = analyzer.validate_data()
-        
+
         assert validation_results["data_loaded"]["valid"] is False
         assert validation_results["profile_data"]["valid"] is False
         assert validation_results["content_found"]["valid"] is False
@@ -295,12 +314,12 @@ class TestInstagramAnalyzerValidation:
     def test_validate_data_partial(self, mock_instagram_data):
         """Test validation with partial data."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
+
         # Only posts, no profile
         analyzer.posts = [MagicMock()]
-        
+
         validation_results = analyzer.validate_data()
-        
+
         assert validation_results["data_loaded"]["valid"] is True
         assert validation_results["profile_data"]["valid"] is False
         assert validation_results["content_found"]["valid"] is True
@@ -312,7 +331,7 @@ class TestInstagramAnalyzerBasicInfo:
     def test_get_basic_info_with_data(self, mock_instagram_data):
         """Test getting basic info with data."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
+
         # Mock profile and content
         analyzer.profile = Profile(
             username="testuser",
@@ -320,21 +339,23 @@ class TestInstagramAnalyzerBasicInfo:
             is_verified=True,
             is_private=False,
         )
-        
+
         test_time = datetime.now(timezone.utc)
         analyzer.posts = [
             Post(
-                media=[Media(
-                    uri="test.jpg",
-                    media_type=MediaType.IMAGE,
-                    creation_timestamp=test_time
-                )],
+                media=[
+                    Media(
+                        uri="test.jpg",
+                        media_type=MediaType.IMAGE,
+                        creation_timestamp=test_time,
+                    )
+                ],
                 timestamp=test_time,
             )
         ]
-        
+
         info = analyzer.get_basic_info()
-        
+
         assert info["username"] == "testuser"
         assert info["display_name"] == "Test User"
         assert info["is_verified"] is True
@@ -345,35 +366,37 @@ class TestInstagramAnalyzerBasicInfo:
     def test_get_basic_info_no_profile(self, mock_instagram_data):
         """Test getting basic info without profile."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
+
         analyzer.posts = [MagicMock()]
-        
+
         info = analyzer.get_basic_info()
-        
+
         assert "username" not in info
         assert info["total_posts"] == 1
 
     def test_get_basic_info_no_dates(self, mock_instagram_data):
         """Test getting basic info with posts that have no timestamps."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
+
         # Create a mock post without a timestamp by setting it after creation
         test_time = datetime.now(timezone.utc)
         post = Post(
-            media=[Media(
-                uri="test.jpg",
-                media_type=MediaType.IMAGE,
-                creation_timestamp=test_time
-            )],
+            media=[
+                Media(
+                    uri="test.jpg",
+                    media_type=MediaType.IMAGE,
+                    creation_timestamp=test_time,
+                )
+            ],
             timestamp=test_time,
         )
-        
+
         # Mock the timestamp to be None for this test
-        post.__dict__['timestamp'] = None
+        post.__dict__["timestamp"] = None
         analyzer.posts = [post]
-        
+
         info = analyzer.get_basic_info()
-        
+
         assert "date_range" not in info
         assert "days_active" not in info
 
@@ -384,46 +407,46 @@ class TestInstagramAnalyzerExports:
     def test_export_json(self, mock_instagram_data, temp_dir):
         """Test JSON export."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
+
         # Mock some analysis results
-        with patch.object(analyzer, 'analyze') as mock_analyze:
+        with patch.object(analyzer, "analyze") as mock_analyze:
             mock_analyze.return_value = {"total_posts": 5, "total_likes": 100}
-            
+
             output_path = temp_dir / "output"
             result_path = analyzer.export_json(output_path)
-            
+
             assert result_path.exists()
             assert result_path.suffix == ".json"
-            
+
             # Verify content
             with open(result_path) as f:
                 data = json.load(f)
-            
+
             assert data["total_posts"] == 5
             assert data["total_likes"] == 100
 
     def test_export_json_with_anonymization(self, mock_instagram_data, temp_dir):
         """Test JSON export with anonymization."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
-        with patch.object(analyzer, 'analyze') as mock_analyze:
+
+        with patch.object(analyzer, "analyze") as mock_analyze:
             mock_analyze.return_value = {"username": "testuser", "total_posts": 5}
-            
+
             output_path = temp_dir / "output"
             result_path = analyzer.export_json(output_path, anonymize=True)
-            
+
             assert result_path.exists()
 
     def test_export_html(self, mock_instagram_data, temp_dir):
         """Test HTML export."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
+
         output_path = temp_dir / "output"
         result_path = analyzer.export_html(output_path)
-        
+
         assert result_path.exists()
         assert result_path.suffix == ".html"
-        
+
         # Verify it's valid HTML
         content = result_path.read_text()
         assert "<!DOCTYPE html>" in content
@@ -432,15 +455,15 @@ class TestInstagramAnalyzerExports:
     def test_export_pdf(self, mock_instagram_data, temp_dir):
         """Test PDF export."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
+
         output_path = temp_dir / "output"
-        
+
         # Mock the PDF exporter to avoid dependencies
-        with patch('instagram_analyzer.exporters.PDFExporter') as mock_pdf:
+        with patch("instagram_analyzer.exporters.PDFExporter") as mock_pdf:
             mock_pdf.return_value.export.return_value = output_path / "test.pdf"
-            
+
             result_path = analyzer.export_pdf(output_path)
-            
+
             assert result_path == output_path / "test.pdf"
             mock_pdf.return_value.export.assert_called_once()
 
@@ -453,7 +476,7 @@ class TestInstagramAnalyzerErrorHandling:
         # Create a directory with no read permissions
         restricted_dir = temp_dir / "restricted"
         restricted_dir.mkdir(mode=0o755)  # Create with normal permissions first
-        
+
         try:
             # Remove permissions after creation
             restricted_dir.chmod(0o000)
@@ -469,42 +492,44 @@ class TestInstagramAnalyzerErrorHandling:
     def test_analyzer_with_memory_constraints(self, mock_instagram_data):
         """Test analyzer behavior under memory constraints."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
+
         # Mock a memory error during analysis
-        with patch.object(analyzer.basic_stats, 'analyze') as mock_analyze:
+        with patch.object(analyzer.basic_stats, "analyze") as mock_analyze:
             mock_analyze.side_effect = MemoryError("Out of memory")
-            
+
             with pytest.raises(MemoryError):
                 analyzer.analyze()
 
     def test_analyzer_logging_integration(self, mock_instagram_data, caplog):
         """Test that logging is properly integrated."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
+
         # Check that initialization was logged
         assert "Initializing InstagramAnalyzer" in caplog.text
 
     def test_analyzer_with_large_dataset_simulation(self, mock_instagram_data):
         """Test analyzer with simulated large dataset."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
+
         # Simulate large dataset
         large_posts = []
         for i in range(1000):
             post = Post(
-                media=[Media(
-                    uri=f"test_{i}.jpg",
-                    media_type=MediaType.IMAGE,
-                    creation_timestamp=datetime.now(timezone.utc)
-                )],
+                media=[
+                    Media(
+                        uri=f"test_{i}.jpg",
+                        media_type=MediaType.IMAGE,
+                        creation_timestamp=datetime.now(timezone.utc),
+                    )
+                ],
                 timestamp=datetime.now(timezone.utc),
                 caption=f"Test post {i}",
                 likes_count=i,
             )
             large_posts.append(post)
-        
+
         analyzer.posts = large_posts
-        
+
         # Should handle large dataset without issues
         results = analyzer.analyze()
         assert results["total_posts"] == 1000
@@ -517,9 +542,9 @@ class TestEndToEndIntegration:
     def test_full_analysis_workflow(self, mock_instagram_data, temp_dir):
         """Test complete analysis workflow from start to finish."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
+
         # Mock complete data structure
-        with patch.object(analyzer.detector, 'detect_structure') as mock_detect:
+        with patch.object(analyzer.detector, "detect_structure") as mock_detect:
             mock_detect.return_value = {
                 "is_valid": True,
                 "export_type": "full_export",
@@ -530,18 +555,18 @@ class TestEndToEndIntegration:
                 "profile_files": [mock_instagram_data / "personal_information.json"],
                 "message_files": [],
             }
-            
+
             # Full workflow
             analyzer.load_data()
             validation_results = analyzer.validate_data()
             basic_info = analyzer.get_basic_info()
             analysis_results = analyzer.analyze()
-            
+
             # Export in all formats
             output_dir = temp_dir / "exports"
             json_path = analyzer.export_json(output_dir)
             html_path = analyzer.export_html(output_dir)
-            
+
             # Verify all steps completed successfully
             assert validation_results["data_loaded"]["valid"]
             assert "total_posts" in basic_info
@@ -552,9 +577,9 @@ class TestEndToEndIntegration:
     def test_workflow_with_errors_and_recovery(self, mock_instagram_data, temp_dir):
         """Test workflow with errors and recovery mechanisms."""
         analyzer = InstagramAnalyzer(mock_instagram_data)
-        
+
         # Simulate partial failure in data loading
-        with patch.object(analyzer.detector, 'detect_structure') as mock_detect:
+        with patch.object(analyzer.detector, "detect_structure") as mock_detect:
             mock_detect.return_value = {
                 "is_valid": True,
                 "export_type": "partial_export",
@@ -565,10 +590,10 @@ class TestEndToEndIntegration:
                 "profile_files": [],
                 "message_files": [],
             }
-            
+
             # Should handle the error gracefully
             analyzer.load_data()
-            
+
             # Analysis should still work with empty data
             results = analyzer.analyze()
             assert results["total_posts"] == 0


### PR DESCRIPTION
## Summary
- aggregate reels with posts in `HTMLExporter._get_overview_stats`
- recompute averages using total posts + reels
- update integration tests for reels

## Testing
- `pre-commit run --files instagram_analyzer/exporters/html_exporter.py tests/integration/test_instagram_analyzer.py` *(failed: Could not install types-all)*
- `pytest --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_e_6877ca906c04832f806d678527fba56c