### PR TITLE
Add network graph analysis and report

### DIFF
--- a/instagram_analyzer/analyzers/__init__.py
+++ b/instagram_analyzer/analyzers/__init__.py
@@ -2,6 +2,7 @@
 
 from .basic_stats import BasicStatsAnalyzer
 from .temporal_analysis import TemporalAnalyzer
+from .network_analysis import NetworkAnalyzer
 # TODO: implement SentimentAnalyzer module
 # from .sentiment_analysis import SentimentAnalyzer
 # TODO: implement NetworkAnalyzer module
@@ -12,6 +13,5 @@ __all__ = [
     "TemporalAnalyzer",
     # TODO: export SentimentAnalyzer when available
     # "SentimentAnalyzer",
-    # TODO: export NetworkAnalyzer when available
-    # "NetworkAnalyzer",
+    "NetworkAnalyzer",
 ]

--- a/instagram_analyzer/analyzers/network_analysis.py
+++ b/instagram_analyzer/analyzers/network_analysis.py
@@ -1,0 +1,47 @@
+from collections import defaultdict
+from typing import Any, Dict, List
+
+from ..models import Post
+
+
+class NetworkAnalyzer:
+    """Build a simple interaction graph from posts."""
+
+    def __init__(self, owner_username: str) -> None:
+        self.owner = owner_username
+
+    def analyze(self, posts: List[Post]) -> Dict[str, Any]:
+        """Generate graph data from mentions, likes and comments."""
+        nodes = set()
+        edges: defaultdict[tuple[str, str], int] = defaultdict(int)
+
+        nodes.add(self.owner)
+
+        for post in posts:
+            # Mentions in post caption
+            for mention in post.mentions:
+                nodes.add(mention)
+                edges[(self.owner, mention)] += 1
+
+            # Likes
+            for like in post.likes:
+                username = like.user.username
+                nodes.add(username)
+                edges[(username, self.owner)] += 1
+
+            # Comments and mentions in comments
+            for comment in post.comments:
+                author = comment.author.username
+                nodes.add(author)
+                edges[(author, self.owner)] += 1
+                for mention in comment.mentions:
+                    nodes.add(mention)
+                    edges[(author, mention)] += 1
+
+        return {
+            "nodes": [{"id": n} for n in nodes],
+            "links": [
+                {"source": s, "target": t, "value": w}
+                for (s, t), w in edges.items()
+            ],
+        }

--- a/instagram_analyzer/exporters/html_exporter.py
+++ b/instagram_analyzer/exporters/html_exporter.py
@@ -12,6 +12,7 @@ from jinja2 import Environment
 
 from .. import __version__
 from ..models import Post, Story, Reel, Profile
+from ..analyzers import NetworkAnalyzer
 from ..utils import (
     get_image_thumbnail,
     resolve_media_path,
@@ -61,6 +62,7 @@ class HTMLExporter:
             "content_analysis": self._get_content_analysis(analyzer),
             "posts": self._get_posts_data(analyzer, anonymize),
             "charts_data": self._get_charts_data(analyzer),
+            "network_graph": self._get_network_graph_data(analyzer),
         }
 
         return data
@@ -447,6 +449,14 @@ class HTMLExporter:
             },
         }
 
+    def _get_network_graph_data(self, analyzer) -> Dict[str, Any]:
+        """Build network graph data using NetworkAnalyzer."""
+        if not analyzer.profile or not analyzer.posts:
+            return {"nodes": [], "links": []}
+
+        network = NetworkAnalyzer(analyzer.profile.username)
+        return network.analyze(analyzer.posts)
+
     def _render_template(self, data: Dict[str, Any]) -> str:
         """Render the HTML template with data using Jinja2."""
         env = Environment(autoescape=False)
@@ -459,6 +469,7 @@ class HTMLExporter:
             "CONTENT": json.dumps(data["content_analysis"], default=str),
             "POSTS": json.dumps(data["posts"], default=str),
             "CHARTS": json.dumps(data["charts_data"], default=str),
+            "NETWORK": json.dumps(data["network_graph"], default=str),
         }
 
         return tmpl.render(context)

--- a/instagram_analyzer/templates/report.html
+++ b/instagram_analyzer/templates/report.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Instagram Analysis Report</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
     <style>
         * {
             margin: 0;
@@ -260,6 +261,7 @@
             <a href="#engagement">Engagement</a>
             <a href="#content">Content</a>
             <a href="#posts">Posts</a>
+            <a href="#network">Network</a>
         </nav>
 
         <!-- Overview Stats -->
@@ -301,6 +303,14 @@
                 <div class="loading">Loading posts...</div>
             </div>
         </div>
+
+        <!-- Network Graph -->
+        <div class="section" id="network">
+            <h2>🔗 Network Graph</h2>
+            <div id="network-graph">
+                <div class="loading">Loading network graph...</div>
+            </div>
+        </div>
     </div>
 
     <script>
@@ -312,6 +322,7 @@
         const content = {{ CONTENT }};
         const posts = {{ POSTS }};
         const charts = {{ CHARTS }};
+        const network = {{ NETWORK }};
         
         // Render metadata
         function renderMetadata() {
@@ -623,6 +634,76 @@
                 }
             });
         }
+
+        // Render network graph with D3.js
+        function renderNetwork() {
+            const container = document.getElementById('network-graph');
+
+            if (!network.nodes.length) {
+                container.innerHTML = '<p>No network data available</p>';
+                return;
+            }
+
+            const width = 600;
+            const height = 400;
+            const svg = d3.create('svg')
+                .attr('width', width)
+                .attr('height', height);
+
+            container.innerHTML = '';
+            container.appendChild(svg.node());
+
+            const link = svg.append('g')
+                .selectAll('line')
+                .data(network.links)
+                .enter().append('line')
+                .attr('stroke', '#999');
+
+            const node = svg.append('g')
+                .selectAll('circle')
+                .data(network.nodes)
+                .enter().append('circle')
+                .attr('r', 5)
+                .attr('fill', '#667eea')
+                .call(d3.drag()
+                    .on('start', dragstarted)
+                    .on('drag', dragged)
+                    .on('end', dragended));
+
+            node.append('title').text(d => d.id);
+
+            const simulation = d3.forceSimulation(network.nodes)
+                .force('link', d3.forceLink(network.links).id(d => d.id).distance(80))
+                .force('charge', d3.forceManyBody().strength(-200))
+                .force('center', d3.forceCenter(width / 2, height / 2));
+
+            simulation.on('tick', () => {
+                link.attr('x1', d => d.source.x)
+                    .attr('y1', d => d.source.y)
+                    .attr('x2', d => d.target.x)
+                    .attr('y2', d => d.target.y);
+
+                node.attr('cx', d => d.x)
+                    .attr('cy', d => d.y);
+            });
+
+            function dragstarted(event, d) {
+                if (!event.active) simulation.alphaTarget(0.3).restart();
+                d.fx = d.x;
+                d.fy = d.y;
+            }
+
+            function dragged(event, d) {
+                d.fx = event.x;
+                d.fy = event.y;
+            }
+
+            function dragended(event, d) {
+                if (!event.active) simulation.alphaTarget(0);
+                d.fx = null;
+                d.fy = null;
+            }
+        }
         
         // Initialize the report
         document.addEventListener('DOMContentLoaded', function() {
@@ -632,6 +713,7 @@
             renderEngagement();
             renderContent();
             renderPosts();
+            renderNetwork();
         });
     </script>
 </body>

--- a/tests/integration/test_instagram_analyzer.py
+++ b/tests/integration/test_instagram_analyzer.py
@@ -428,6 +428,7 @@ class TestInstagramAnalyzerExports:
         content = result_path.read_text()
         assert "<!DOCTYPE html>" in content
         assert "<html>" in content
+        assert "network-graph" in content
 
     def test_export_pdf(self, mock_instagram_data, temp_dir):
         """Test PDF export."""

--- a/tests/unit/test_html_exporter_template.py
+++ b/tests/unit/test_html_exporter_template.py
@@ -11,6 +11,7 @@ def test_template_contains_nav_and_hourly_chart():
     )
     assert "nav-menu" in template
     assert "hourly-chart" in template
+    assert "network-graph" in template
 
 
 def test_template_contains_key_placeholders():
@@ -24,6 +25,7 @@ def test_template_contains_key_placeholders():
         "engagement-analysis",
         "content-analysis",
         "posts-gallery",
+        "network-graph",
     ]
 
     for name in placeholders:
@@ -41,6 +43,7 @@ def test_render_template_injects_json():
         "content_analysis": {"hashtags": {"total_unique": 0}},
         "posts": [],
         "charts_data": {},
+        "network_graph": {"nodes": [], "links": []},
     }
 
     rendered = exporter._render_template(data)
@@ -49,3 +52,4 @@ def test_render_template_injects_json():
     assert json.dumps(data["overview"], default=str) in rendered
     assert json.dumps(data["temporal_analysis"], default=str) in rendered
     assert json.dumps(data["engagement_analysis"], default=str) in rendered
+    assert json.dumps(data["network_graph"], default=str) in rendered


### PR DESCRIPTION
## Summary
- implement `NetworkAnalyzer` for building interaction graphs
- include network graph data in `HTMLExporter`
- update HTML template with D3.js graph and navigation link
- extend tests for new graph section

## Testing
- `pytest -q` *(fails: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_6877cacd3178832fb3a8263d5e3f8f9d