### PR TITLE
Fix counts for empty arrays

### DIFF
--- a/instagram_analyzer/parsers/json_parser.py
+++ b/instagram_analyzer/parsers/json_parser.py
@@ -104,6 +104,9 @@ class JSONParser:
         hashtags = self._extract_hashtags(caption)
         mentions = self._extract_mentions(caption)
         
+        likes_count = data.get("like_count", len(likes))
+        comments_count = data.get("comment_count", len(comments))
+
         return Post(
             caption=caption,
             media=media_list,
@@ -112,11 +115,11 @@ class JSONParser:
             location=data.get("location", {}).get("name") if data.get("location") else None,
             likes=likes,
             comments=comments,
-            likes_count=len(likes) or data.get("like_count", 0),
-            comments_count=len(comments) or data.get("comment_count", 0),
+            likes_count=likes_count,
+            comments_count=comments_count,
             hashtags=hashtags,
             mentions=mentions,
-            raw_data=data
+            raw_data=data,
         )
     
     def parse_stories(self, data: List[Dict[str, Any]]) -> List[Story]:

--- a/tests/unit/test_json_parser.py
+++ b/tests/unit/test_json_parser.py
@@ -1,0 +1,20 @@
+import datetime
+from instagram_analyzer.parsers.json_parser import JSONParser
+
+
+def test_parse_single_post_counts_with_empty_arrays():
+    parser = JSONParser()
+    data = {
+        "media": [{"uri": "img.jpg", "creation_timestamp": 1609459200}],
+        "creation_timestamp": 1609459200,
+        "likes": [],
+        "comments": [],
+        "like_count": 5,
+        "comment_count": 3,
+    }
+
+    post = parser._parse_single_post(data)
+
+    assert post is not None
+    assert post.likes_count == 5
+    assert post.comments_count == 3


### PR DESCRIPTION
## Summary
- ensure numeric count fields override list length when parsing posts
- add regression test verifying post counts

## Testing
- `pre-commit run --files instagram_analyzer/parsers/json_parser.py tests/unit/test_json_parser.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877caf0dad4832fb2fe5fb13a661b97